### PR TITLE
Add model itself as params to dataForCustomAction

### DIFF
--- a/addon/actions/action.js
+++ b/addon/actions/action.js
@@ -247,7 +247,8 @@ export default EmberObject.extend({
   _dataForCustomAction(data) {
     let actionId = this.get('id');
     let modelId = this.get('model.id');
+    let model = this.get('model');
 
-    return this.get('adapter').dataForCustomAction({ data, actionId, modelId });
+    return this.get('adapter').dataForCustomAction({ data, actionId, modelId, model });
   }
 });


### PR DESCRIPTION
I need the same contribution I made to the original repo: https://github.com/Exelord/ember-custom-actions/commit/2401cde1fdaad8f6c8cd13b9adb1ce1c37939b06

I did not check we were using a forked version :( I was waiting for a new release from the original repo via npm. Then I realized we have our own fork. I need an updated version with the commit within this PR soon.